### PR TITLE
set claimCommission

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,7 +128,9 @@ const Home: NextPage = () => {
             </Button>
             <Button
               handleClick={claimCommissions}
-              disabled={!ownerAddress}
+              disabled={true}
+              // todo: After it's enable to claimCommissions, enable following code.
+              // disabled={!ownerAddress}
             >
               Claim Commissions
             </Button>


### PR DESCRIPTION
# display button, but it is disabled
There is an UPDATE on codeCommission's contract.
That's why codeCommission's button is disabled.
<img width="569" alt="スクリーンショット 2022-10-31 16 10 38" src="https://user-images.githubusercontent.com/57980707/198951572-ad761f4a-85ab-400c-83b4-0023d0f86d25.png">

https://github.com/oasysgames/oasys-pos-fe/pull/6/commits/ccc98a5af34294519ce8da2b4c2d8d312d807192

# operation check

## Success 
https://user-images.githubusercontent.com/57980707/198932448-39ecf204-a1b3-48b2-a89b-f88ac96a5794.mov

## Failure
https://user-images.githubusercontent.com/57980707/198932495-9ef5bbc7-bb8e-449f-9fc2-3b9056c357ec.mov

