### PR TITLE
remove error when account_change at update_bridge_page

### DIFF
--- a/src/pages/update-bridge.tsx
+++ b/src/pages/update-bridge.tsx
@@ -77,17 +77,20 @@ const UpdateBridge: NextPage = () => {
     setPreERC721BridgeBytecode(bytecode);
   }
 
-  const setPreBridgeContractBytecode = async (l1StandardBridgeProxyAddress: string, l1ERC721BridgeProxyAddress: string) => {
+  const setPreBridgeContractBytecode = useCallback(async (l1StandardBridgeProxyAddress: string, l1ERC721BridgeProxyAddress: string) => {
     await setPreERC20BridgeContractBytecode(l1StandardBridgeProxyAddress);
     await setPreERC721BridgeContractBytecode(l1ERC721BridgeProxyAddress);
-  }
+  }, []);
 
   useEffect(() => {
     handleAccountsChanged();
+  });
+
+  useEffect(() => {
     if (verseInfo?.namedAddresses) {
       setPreBridgeContractBytecode(verseInfo.namedAddresses.Proxy__OVM_L1StandardBridge, verseInfo.namedAddresses.Proxy__OVM_L1ERC721Bridge);
     }
-  });
+  }, [setPreBridgeContractBytecode, verseInfo]);
 
   useEffect(() => {
     refreshVerseInfo();


### PR DESCRIPTION
# Bug
When checkout to another account not built verse, Console.error happens.
<img width="1220" alt="Screenshot 2023-06-15 at 13 59 17" src="https://github.com/oasysgames/oasys-pos-fe/assets/57980707/22c56445-7509-4558-a133-db4ebbdc476e">

# Bug reason
The error is occurring because it is going to get the bytecode of the bridge using the address information of the verse of the account before checking out.
